### PR TITLE
Use `sharedKey` to invalidate existing cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: cache-v1
 
       - name: Build
         run: cargo build --locked --verbose


### PR DESCRIPTION
Invalidate the existing cache by using `sharedKey` in rust-cache.
`sharedKey` is now `cache-v1`.
As a known workaround, we can invalidate existing cache by incrementing `v1`.