### PR TITLE
ci: fix a bug that prebuilt binaries aren't published to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           PKG_SUFFIX=".tar.gz" ; case "${{ matrix.job.target }}" in *-pc-windows-*) PKG_SUFFIX=".zip" ;; esac;
           PKG_BASENAME="${PROJECT_NAME}-v${{ steps.project_version.outputs.PROJECT_VERSION }}-${{ matrix.job.target }}"
           PKG_PATH="${PKG_BASENAME}${PKG_SUFFIX}"
-          echo "PKG_PATH=${PKG_PATH}" >> "${GITHUB_ENV}"
+          echo "PKG_PATH=${PKG_PATH}" >> "${GITHUB_OUTPUT}"
 
           PKG_DIR="archive"
           mkdir -p "${PKG_DIR}"


### PR DESCRIPTION
omekasy v1.2.1 and v1.2.2 don't have prebuilt binaries.

https://github.com/ikanago/omekasy/releases/tag/v1.2.2

<img width="279" alt="image" src="https://github.com/ikanago/omekasy/assets/13323303/d7894e05-278b-447d-b1c1-39258c7cc71d">

Prebuilt binaries were built in CI, but they weren't published because the input of softprops/action-gh-release `files` is empty.

https://github.com/ikanago/omekasy/actions/runs/6284001639/job/17064954741

```
Run softprops/action-gh-release@v1
  with:
    token: ***
  env:
    PROJECT_NAME: omekasy
    PKG_PATH: omekasy-v1.2.2-x86_64-unknown-linux-gnu.tar.gz
    GITHUB_TOKEN: ***
👩‍🏭 Creating new GitHub release for tag v1.2.2...
🤔  not include valid file.
🎉 Release ready at https://github.com/ikanago/omekasy/releases/tag/v1.2.2
```
